### PR TITLE
Revert "Test helm-repo-html fix"

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Update index.html
         run: |
-          helm plugin list | grep -q repo-html || helm plugin install https://github.com/jtomasek/helm-repo-html
+          helm plugin list | grep -q repo-html || helm plugin install https://github.com/halkeye/helm-repo-html
           helm repo-html -t index.tpl
           git add ./index.html
           git commit -a -m "Update index.html"


### PR DESCRIPTION
Since the repository installation has been fixed we can revert back to using it.

This reverts commit db5ea8624384bfefeb2b6d6525ddb10ca408f894.