### PR TITLE
KubeVirt extension bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suse-edge-dashboard-extensions",
-  "version": "1.0.0-dev.2",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "private": false,
   "engines": {

--- a/pkg/kubevirt-dashboard-extension/actions.ts
+++ b/pkg/kubevirt-dashboard-extension/actions.ts
@@ -34,7 +34,7 @@ export const startVMAction: Action = {
 
 export const stopVMAction: Action = {
   label: 'Stop',
-  icon: 'icon-pause',
+  icon: 'icon-close',
   invoke: stopVMs,
   enabled: canStopVM,
   multiple: true,

--- a/pkg/kubevirt-dashboard-extension/l10n/en-us.yaml
+++ b/pkg/kubevirt-dashboard-extension/l10n/en-us.yaml
@@ -1,3 +1,5 @@
+product:
+  kubevirt: KubeVirt
 kubevirt:
   productLabel: 'Kubevirt Product label from i18n file'
   modal:
@@ -694,6 +696,11 @@ typeLabel:
     {count, plural,
       one { Virtual Machine }
       other { Virtual Machines }
+    }
+  kubevirt.io.virtualmachineinstance: |-
+    {count, plural,
+      one { Virtual Machine Instance }
+      other { Virtual Machine Instances }
     }
   harvesterhci.io.virtualmachineimage: |-
     {count, plural,

--- a/pkg/kubevirt-dashboard-extension/list/kubevirt.io.virtualmachine.vue
+++ b/pkg/kubevirt-dashboard-extension/list/kubevirt.io.virtualmachine.vue
@@ -56,6 +56,11 @@ export default {
         NAME,
         NAMESPACE,
         {
+          name: 'RunStrategy',
+          label: 'Run Strategy',
+          value: 'runStrategyLabel',
+        },
+        {
           name: 'CPU',
           label: 'CPU',
           sort: ['cpuCores'],

--- a/pkg/kubevirt-dashboard-extension/models/kubevirt.io.virtualmachine.js
+++ b/pkg/kubevirt-dashboard-extension/models/kubevirt.io.virtualmachine.js
@@ -94,7 +94,9 @@ export default class VirtualMachine extends SteveModel {
   get displayMemory() {
     return (
       this.spec.template.spec.domain.resources?.limits?.memory ||
-      this.spec.template.spec.domain.resources?.requests?.memory
+      this.spec.template.spec.domain.resources?.requests?.memory ||
+      this.spec.template.spec.domain.memory?.guest ||
+      '0Gi'
     );
   }
 

--- a/pkg/kubevirt-dashboard-extension/package.json
+++ b/pkg/kubevirt-dashboard-extension/package.json
@@ -2,7 +2,7 @@
   "name": "kubevirt-dashboard-extension",
   "description": "SUSE Edge: KubeVirt extension for Rancher Dashboard",
   "icon": "https://raw.githubusercontent.com/cncf/artwork/master/projects/kubevirt/icon/color/kubevirt-icon-color.svg",
-  "version": "1.0.0-dev.2",
+  "version": "1.0.0-dev.3",
   "license": "Apache-2.0",
   "private": false,
   "rancher": {

--- a/pkg/kubevirt-dashboard-extension/product.ts
+++ b/pkg/kubevirt-dashboard-extension/product.ts
@@ -15,5 +15,6 @@ export function init(plugin: IPlugin, store: any) {
     ifHaveType: KUBEVIRT_RESOURCE_NAME,
   });
 
-  basicType([KUBEVIRT_RESOURCE_NAME, VM_RESOURCE_NAME, VMI_RESOURCE_NAME]);
+  // basicType([KUBEVIRT_RESOURCE_NAME, VM_RESOURCE_NAME, VMI_RESOURCE_NAME]);
+  basicType([VM_RESOURCE_NAME, VMI_RESOURCE_NAME]);
 }


### PR DESCRIPTION
- Reorganize KubeVirt navigation section and update labels
- Remove KubeVirts section from the extension navigation
- Update Stop VM action icon
- Add RunStrategy VM column to help user understand the VM operation mode
- Fix VM memory column when the memory is defined using `spec.template.spec.domain.memory.guest`