### PR TITLE
Use latest build-extension-* jobs

### DIFF
--- a/.github/workflows/build-extension-catalog.yml
+++ b/.github/workflows/build-extension-catalog.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   build-extension-catalog:
-    uses: rancher/dashboard/.github/workflows/build-extension-catalog.yml@release-2.10
+    uses: rancher/dashboard/.github/workflows/build-extension-catalog.yml@master
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   build-extension-charts:
-    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@release-2.10
+    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@master
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
This is necessary due to 2.10 jobs having deprecated packages https://github.com/suse-edge/dashboard-extensions/actions/runs/13542627030/job/37846957818