### PR TITLE
[kubevirt] Use spec.runStrategy to perform VM start/stop actions

### DIFF
--- a/pkg/kubevirt-dashboard-extension/actions.ts
+++ b/pkg/kubevirt-dashboard-extension/actions.ts
@@ -9,14 +9,16 @@ type VirtualMachine = VirtualMachineModel & {
 
 const startVMs: Action['invoke'] = function (opts, resources: VirtualMachine[]) {
   resources.map((resource) => {
-    resource.spec.running = true;
+    delete resource.spec.running;
+    resource.spec.runStrategy = 'Always';
     resource.save();
   });
 };
 
 const stopVMs: Action['invoke'] = function (opts, resources: VirtualMachine[]) {
   resources.map((resource) => {
-    resource.spec.running = false;
+    delete resource.spec.running;
+    resource.spec.runStrategy = 'Halted';
     resource.save();
   });
 };

--- a/pkg/kubevirt-dashboard-extension/models/kubevirt.io.virtualmachine.js
+++ b/pkg/kubevirt-dashboard-extension/models/kubevirt.io.virtualmachine.js
@@ -69,11 +69,11 @@ const IgnoreMessages = ['pod has unbound immediate PersistentVolumeClaims'];
 
 export default class VirtualMachine extends SteveModel {
   get canStart() {
-    return !this.spec.runStrategy && !this.spec.running;
+    return this.spec.runStrategy === 'Halted' || this.spec.running === false;
   }
 
   get canStop() {
-    return !this.spec.runStrategy && this.spec.running;
+    return this.spec.runStrategy !== 'Halted' || this.spec.running === true;
   }
 
   get runStrategyLabel() {


### PR DESCRIPTION
spec.running property is deprecated https://kubevirt.io/user-guide/release_notes/#deprecation_1 Using runStrategy to start/stop https://kubevirt.io/user-guide/architecture/#starting-and-stopping